### PR TITLE
Adds AARCH64 Support for Rumprun Sel4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,13 @@ elseif(KernelArchARM)
         set(rumprun_tool_prefix "arm--netbsdelf-eabi")
         # Suppress warnings that would otherwise stop the compilation
         list(APPEND RUMPKERNEL_FLAGS -F CWARNFLAGS=-w)
+    else()
+	set(rumprun_arch "aarch64")
+	set(rumprun_sel4_arch "aarch64")
+	set(rumprun_tuple "aarch64-rumprun-netbsd")
+	set(rumprun_tool_prefix "aarch64-netbsd")
+	# Suppress warnings that would otherwise stop the compilation
+	list(APPEND RUMPKERNEL_FLAGS -F CWARNFLAGS=-w)
     endif()
     # Append -march flag to ensure Rump is built properly for the specific CPU arch
     list(APPEND RUMPKERNEL_FLAGS -F ACFLAGS='-march=${KernelArmArmV}')

--- a/buildrump.sh.patches/0003-Rumprun-aarch64-quickfix.patch
+++ b/buildrump.sh.patches/0003-Rumprun-aarch64-quickfix.patch
@@ -1,0 +1,27 @@
+diff --git a/buildrump.sh b/buildrump.sh
+index e5f3a93..025cfa3 100755
+--- a/buildrump.sh
++++ b/buildrump.sh
+@@ -783,17 +783,22 @@ makebuild ()
+        [ -d ${SRCDIR}/sys/rump/share ] \
+            && appendvar DIRS_second ${SRCDIR}/sys/rump/share
+
+-       if [ ${MACHINE} = "i386" -o ${MACHINE} = "amd64" \
++       if [ ${MACHINE} = "i386" -o ${MACHINE} = "amd64" -o ${MACHINE} = "evbarm64-el"\
+             -o ${MACHINE#evbearm} != ${MACHINE} \
+             -o ${MACHINE#evbppc} != ${MACHINE} ]; then
++               :'
+                DIRS_emul=sys/rump/kern/lib/libsys_linux
++               '
++               DIRS_emul=
+        fi
++
+        ${SYS_SUNOS} && appendvar DIRS_emul sys/rump/kern/lib/libsys_sunos
+        if ${HIJACK}; then
+                DIRS_final="lib/librumphijack"
+        else
+                DIRS_final=
+        fi
++
+
+        DIRS_third="${DIRS_third} ${DIRS_emul}"

--- a/include/bmk-core/aarch64/asm.h
+++ b/include/bmk-core/aarch64/asm.h
@@ -1,0 +1,32 @@
+/*-
+ * Copyright (c) 2014 Antti Kantee.  All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _BMK_CORE_AARCH64_ASM_H_
+#define _BMK_CORE_AARCH64_ASM_H_
+
+#define ENTRY(x)        .text; .globl x; .type x,%function; x:
+#define END(x)          .size x, . - x
+
+#endif /* _BMK_CORE_AARCH64_ASM_H_ */

--- a/init-sources.sh
+++ b/init-sources.sh
@@ -20,5 +20,6 @@ git submodule init
 git submodule update "$@"
 
 # Apply submodule patches
+# we are not applying any net-bsd patches
 (cd buildrump.sh && git am ../buildrump.sh.patches/*)
 touch .rumpstamp

--- a/lib/libbmk_core/arch/aarch64/Makefile.inc
+++ b/lib/libbmk_core/arch/aarch64/Makefile.inc
@@ -1,0 +1,8 @@
+MYDIR:=	${.PARSEDIR}
+.PATH:	${MYDIR}
+
+# __aeabi_read_tp.S has been removed from srcs
+# TODO : add it back for hw support
+
+SRCS+=	cpu_sched_switch.S
+SRCS+=	cpu_sched.c

--- a/lib/libbmk_core/arch/aarch64/__aeabi_read_tp.S
+++ b/lib/libbmk_core/arch/aarch64/__aeabi_read_tp.S
@@ -1,0 +1,34 @@
+/*-
+ * Copyright (c) 2015 Antti Kantee.  All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <bmk-core/aarch64/asm.h>
+
+/* Should use cp15 */
+
+ENTRY(__aeabi_read_tp)
+	ldr x0, =bmk_cpu_arm_curtcb
+	ldr x0, [x0]
+	ret
+END(__aeabi_read_tp)

--- a/lib/libbmk_core/arch/aarch64/cpu_sched.c
+++ b/lib/libbmk_core/arch/aarch64/cpu_sched.c
@@ -1,0 +1,67 @@
+/*
+ ****************************************************************************
+ * (C) 2005 - Grzegorz Milos - Intel Research Cambridge
+ ****************************************************************************
+ *
+ *        File: sched.c
+ *      Author: Grzegorz Milos
+ *     Changes: Robert Kaiser
+ *
+ *        Date: Aug 2005
+ *
+ * Environment: Xen Minimal OS
+ * Description: simple scheduler for Mini-Os
+ *
+ * The scheduler is non-preemptive (cooperative), and schedules according
+ * to Round Robin algorithm.
+ *
+ ****************************************************************************
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <bmk-core/core.h>
+#include <bmk-core/sched.h>
+
+static void
+stack_push(void **stackp, unsigned long value)
+{
+	unsigned long *stack = *stackp;
+
+	stack--;
+	*stack = value;
+	*stackp = stack;
+}
+
+void
+bmk_cpu_sched_create(struct bmk_thread *thread, struct bmk_tcb *tcb,
+	void (*f)(void *), void *arg,
+	void *stack_base, unsigned long stack_size)
+{
+	void *stack_top = (char *)stack_base + stack_size;
+
+	/* Save pointer to the thread on the stack, used by current macro */
+	*(unsigned long *)stack_base = (unsigned long)thread;
+
+	/* these values are used by bmk_cpu_sched_bouncer() */
+	stack_push(&stack_top, (unsigned long)f);
+	stack_push(&stack_top, (unsigned long)arg);
+
+	tcb->btcb_sp = (unsigned long)stack_top;
+	tcb->btcb_ip = (unsigned long)bmk_cpu_sched_bouncer;
+}

--- a/lib/libbmk_core/arch/aarch64/cpu_sched_switch.S
+++ b/lib/libbmk_core/arch/aarch64/cpu_sched_switch.S
@@ -1,0 +1,74 @@
+/*-
+ * Copyright (c) 2015 Antti Kantee.  All Rights Reserved.
+ *
+ *
+ *        File: cpu_sched_switch.S
+ *      Author: Ajay Rahul Pradeep
+ *
+ *        Date: April 2023
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <bmk-core/arm/asm.h>
+
+ENTRY(bmk_cpu_sched_bouncer)
+	// Pop the function and argument from the stack.
+    mov  sp, x29
+    ldp x0, x6, [sp], #16
+    mov x30, lr
+    br x6			// branch to the function address
+    bl bmk_sched_exit		// call
+END(bmk_cpu_sched_bouncer)
+
+
+/*
+ * x0 = previous thread
+ * x1 = new thread
+ */
+
+ENTRY(bmk_cpu_sched_switch)
+        stp x19, x20, [sp, #-16]!     // save non-scratch registers
+        stp x21, x22, [sp, #-16]!
+        stp x23, x24, [sp, #-16]!
+        stp x25, x26, [sp, #-16]!
+        stp x27, x28, [sp, #-16]!
+        stp x29, x30, [sp, #-16]!     // save fp and lr
+		mov x29, sp					  // save stack ptr in x29	
+		str x29, [x0, #0]			  // Save SP and LR of the current thread
+		ldr x29, [x1, #0]   		  // Load SP of the next thread
+		mov sp, x29					  // load sp from x29	
+		mov x19, x0     			  // Using temp register to save value of x0
+		mov x20, x1
+
+		adr x2, 1f                    // save pc
+		str x2, [x19, #8]
+		ldr x30, [x20, #8]            // restore pc
+		br x30
+1:
+        ldp x29, x30, [sp], #16       // restore fp and lr
+		ldp x27, x28, [sp], #16       // restore registers
+        ldp x25, x26, [sp], #16
+        ldp x23, x24, [sp], #16
+        ldp x21, x22, [sp], #16
+        ldp x19, x20, [sp], #16
+        ret
+END(bmk_cpu_sched_switch)

--- a/platform/hw/arch/aarch64/integrator/Makefile.inc
+++ b/platform/hw/arch/aarch64/integrator/Makefile.inc
@@ -1,0 +1,10 @@
+ASMS=	arch/arm/integrator/locore.S
+
+SRCS+=	arch/arm/integrator/machdep.c
+SRCS+=	arch/arm/integrator/serialcons.c
+
+CPPFLAGS+=	-Iarch/arm
+
+.PHONY: archdirs
+archdirs:
+	mkdir -p ${RROBJ}/platform/arch/arm/integrator

--- a/platform/hw/arch/aarch64/integrator/boardreg.h
+++ b/platform/hw/arch/aarch64/integrator/boardreg.h
@@ -1,0 +1,36 @@
+#define UART0		0x16000000	/* uart address */
+
+#define UARTDR		0x0000		/* data register */
+#define UARTFR		0x0018		/* flag register */
+
+#define UARTFR_TXFE	0x80		/* fifo empty */
+
+
+#define TMR1		0x13000100	/* timer base address */
+#define TMR2		0x13000200	/* timer base address */
+
+#define TMR1_LOAD	TMR1 + 0x00	/* load value to decrement */
+#define TMR1_VALUE	TMR1 + 0x04	/* current value */
+#define TMR1_CTRL	TMR1 + 0x08	/* control register */
+#define TMR1_CLRINT	TMR1 + 0x0c	/* clear interrupt by writing here */
+
+#define TMR2_LOAD	TMR2 + 0x00	/* load value to decrement */
+#define TMR2_VALUE	TMR2 + 0x04	/* current value */
+#define TMR2_CTRL	TMR2 + 0x08	/* control register */
+#define TMR2_CLRINT	TMR2 + 0x0c	/* clear interrupt by writing here */
+
+#define TMR_CTRL_EN	0x80		/* timer enabled */
+#define TMR_CTRL_PER	0x40		/* periodic (loop to value) */
+#define TMR_CTRL_IE	0x20		/* interrupt enable */
+#define TMR_CTRL_D256	0x08		/* divide clock by 256 */
+#define TMR_CTRL_D16	0x04		/* divide clock by 16 */
+#define TMR_CTRL_32	0x02		/* 16/32bit timer */
+
+
+#define INTR_BASE	0x14000000	/* irq control base */
+
+#define INTR_STATUS	INTR_BASE + 0x0	/* current status */
+#define INTR_ENABLE	INTR_BASE + 0x8	/* enable irqs */
+#define INTR_CLEAR	INTR_BASE + 0xc	/* clear irqs */
+
+#define CM_SDRAM	0x10000020	/* sdram control register */

--- a/platform/hw/arch/aarch64/integrator/kern.ldscript
+++ b/platform/hw/arch/aarch64/integrator/kern.ldscript
@@ -1,0 +1,75 @@
+OUTPUT_ARCH(arm)
+ENTRY(_start)
+SECTIONS
+{
+	. = 1m;
+	_begin = . ;
+	.text :
+	AT (ADDR(.text) & 0x0fffffff)
+	{
+		*(.start)
+		*(.text)
+		*(.text.*)
+		*(.stub)
+		*(.note*)
+	}
+	_etext = . ;
+
+	.rodata :
+	AT (LOADADDR(.text) + (ADDR(.rodata) - ADDR(.text)))
+	{
+		*(.rodata)
+		*(.rodata.*)
+	}
+
+	.initfini :
+	AT (LOADADDR(.text) + (ADDR(.initfini) - ADDR(.text)))
+	{
+		__init_array_start = . ;
+		*(SORT_BY_INIT_PRIORITY(.init_array.*))
+		*(SORT_BY_INIT_PRIORITY(.ctors*))
+		*(.init_array)
+		__init_array_end = . ;
+		__fini_array_start = . ;
+		*(SORT_BY_INIT_PRIORITY(.fini_array.*))
+		*(SORT_BY_INIT_PRIORITY(.dtors*))
+		*(.fini_array)
+		__fini_array_end = . ;
+	}
+
+	_data_start = .;
+	.data :
+	AT (LOADADDR(.text) + (ADDR(.data) - ADDR(.text)))
+	{
+		*(.data)
+	}
+	_edata = . ;
+
+	.tdata :
+	AT (LOADADDR(.text) + (ADDR(.tdata) - ADDR(.text)))
+	{
+		_rump_tdata_start = . ;
+		*(.tdata)
+		_rump_tdata_end = . ;
+	}
+
+	.tbss :
+	AT (LOADADDR(.text) + (ADDR(.tbss) - ADDR(.text)))
+	{
+		_rump_tbss_start = . ;
+		*(.tbss)
+		_rump_tbss_end = . ;
+	}
+
+	__bss_start = . ;
+	.bss :
+	AT (LOADADDR(.text) + (ADDR(.bss) - ADDR(.text)))
+	{
+		*(.bss)
+		*(.bss.*)
+		*(COMMON)
+		*(.bootstack)
+	}
+	_end = . ;
+	PROVIDE (end = .) ;
+}

--- a/platform/hw/arch/aarch64/integrator/locore.S
+++ b/platform/hw/arch/aarch64/integrator/locore.S
@@ -1,0 +1,136 @@
+/*-
+ * Copyright (c) 2015 Antti Kantee.  All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/**
+TODO : Convert this code to AARCH64s
+**/
+
+#include <hw/kernel.h>
+
+.space 4096
+bootstack:
+.space 4096
+undefstack:
+.space 4096
+irqstack:
+
+.section .start,"ax",%progbits
+
+.globl _start
+_start:
+	/* set undefined stack */
+	mrs r0, cpsr
+	bic r0, r0, #0x1f
+	orr r0, r0, #0x1b
+	msr cpsr, r0
+	ldr sp, =undefstack
+
+	bic r0, r0, #0x1f
+	orr r0, r0, #0x12
+	msr cpsr, r0
+	ldr sp, =irqstack
+
+	bic r0, r0, #0x1f
+	orr r0, r0, #0x13
+	msr cpsr, r0
+	ldr sp, =bootstack
+	bl arm_boot
+	b haltme
+
+haltme:
+	b haltme
+
+/*
+ * "exception" vectors
+ */
+.globl vector_start, vector_end
+vector_start:
+	ldr pc, [pc, #24]
+	ldr pc, [pc, #24]
+	ldr pc, [pc, #24]
+	ldr pc, [pc, #24]
+	ldr pc, [pc, #24]
+	nop
+	ldr pc, [pc, #24]
+	ldr pc, [pc, #24]
+
+	.word	vector__start
+	.word	vector_undefined
+	.word	vector_softint
+	.word	vector_prefetch_abort
+	.word	vector_data_abort
+	.word	0
+	.word	vector_irq
+	.word	vector_fiq
+vector_end:
+
+vector__start:
+	b vector__start
+
+vector_undefined:
+	push {r0-r14}
+	adds r0, sp, #(14*4)
+	bl arm_undefined
+	pop {r0-r14}
+	movs pc, lr
+
+vector_irq:
+	push {r0-r14}
+	adds r0, sp, #(14*4)
+	bl arm_interrupt
+	pop {r0-r14}
+	subs pc, r14, #4
+
+/*
+ * The rest of the exceptions just loop.  Attach a debugger
+ * to find out where you are currently.
+ */
+
+vector_softint:
+	b vector_softint
+
+vector_prefetch_abort:
+	b vector_prefetch_abort
+
+vector_data_abort:
+	b vector_data_abort
+
+vector_fiq:
+	b vector_fiq
+
+
+ENTRY(splhigh)
+	mrs	r0, cpsr
+        orr	r0, r0, #(1<<7)
+        msr	cpsr_c, r0
+	bx lr
+END(splhigh)
+
+ENTRY(spl0)
+	mrs	r0, cpsr
+        bic	r0, r0, #(1<<7)
+        msr	cpsr_c, r0
+	bx lr
+END(spl0)

--- a/platform/hw/arch/aarch64/integrator/machdep.c
+++ b/platform/hw/arch/aarch64/integrator/machdep.c
@@ -1,0 +1,208 @@
+/*-
+ * Copyright (c) 2015 Antti Kantee.  All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * TODO: maybe this doesn't have to be board-specific expect for loadmme()?
+ * IIRC NetBSD has a copypasted initarm() but Linux has a unified one,
+ * and since our requirements are much simpler than those of NetBSD/Linux,
+ * a common one should definitely work out.
+ */
+
+/*
+TODO : Convert this code to AARCH64
+*/
+#include <hw/types.h>
+#include <hw/kernel.h>
+
+#include <bmk-core/core.h>
+#include <bmk-core/mainthread.h>
+#include <bmk-core/pgalloc.h>
+#include <bmk-core/platform.h>
+#include <bmk-core/printf.h>
+#include <bmk-core/sched.h>
+#include <bmk-core/string.h>
+
+#include <integrator/boardreg.h>
+
+static void
+loadmem(void)
+{
+	extern char _end[];
+	unsigned long osend = bmk_round_page((unsigned long)_end);
+	int meminfo = (*(unsigned long *)CM_SDRAM & 0x1f) >> 2;
+	int memend;
+
+	bmk_assert(meminfo <= 4);
+	memend = (1<<meminfo) * 16*1024*1024;
+
+	bmk_pgalloc_loadmem(osend, memend);
+	bmk_memsize = memend - osend;
+}
+
+static void
+clockinit(void)
+{
+
+	/* XXX: timer will wrap in ~10 days, FIXXME */
+	outl(TMR1_CTRL, TMR_CTRL_EN | TMR_CTRL_D256 | TMR_CTRL_32);
+	outl(TMR1_CLRINT, 0);
+}
+
+static char cmdline[] = "\n"
+"{\n"
+"	cmdline: \"HELLO just dropping by\n\",\n"
+"	net :  {\n"
+"		\"if\":		\"sm0\",\n"
+"		\"type\":	\"inet\",\n"
+"		\"method\":	\"static\",\n"
+"		\"addr\":	\"10.0.0.2\",\n"
+"		\"mask\":	\"24\",\n"
+"	}\n"
+"}\n";
+
+void
+arm_boot(void)
+{
+	extern char vector_start[], vector_end[];
+
+	bmk_memcpy((void *)0, vector_start, vector_end - vector_start);
+
+	bmk_printf_init(cons_putc, NULL);
+	bmk_printf("rump kernel bare metal bootstrap (ARM)\n\n");
+
+	bmk_sched_init();
+
+	bmk_core_init(BMK_THREAD_STACK_PAGE_ORDER);
+	loadmem();
+
+	clockinit();
+	intr_init();
+
+	spl0();
+
+	bmk_sched_startmain(bmk_mainthread, cmdline);
+}
+
+unsigned long bmk_cpu_arm_curtcb = 0;
+
+void
+arm_undefined(unsigned long *trapregs)
+{
+	unsigned long instaddr = *(trapregs);
+	unsigned long instr = *(unsigned long *)(instaddr-4);
+	int reg = (instr >> 12) & 0xf;
+
+	if ((instr & 0xffff0fff) == 0xee1d0f70 && reg <= 12) {
+		*((trapregs-14)+reg) = bmk_cpu_arm_curtcb;
+	} else {
+		bmk_platform_halt("undefined instruction");
+	}
+}
+
+/* no interrupt handler for the timer, so we just clear it */
+static unsigned int clearmask = 0x80;
+
+/* dynamically registered interrupts */
+static unsigned int intmask;
+
+void
+arm_interrupt(unsigned long *trapregs)
+{
+	uint32_t intstat = inl(INTR_STATUS);
+	uint32_t clearint = intstat & clearmask;
+
+	splhigh();
+
+	if (clearint) {
+		outl(INTR_CLEAR, clearint);
+		intstat &= ~clearint;
+	}
+
+	if (intstat) {
+		outl(INTR_CLEAR, intstat);
+		isr(intstat);
+	}
+
+	spl0();
+}
+
+void
+bmk_platform_cpu_sched_settls(struct bmk_tcb *next)
+{
+
+	bmk_cpu_arm_curtcb = next->btcb_tp;
+#ifdef notonthisarm
+	asm volatile("mcr p15, 0, %0, c13, c0, 2" :: "r"(next->btcb_tp));
+#endif
+}
+
+/* timer is 1MHz, we use divisor 256 */
+#define NSEC_PER_TICK ((1000*1000*1000ULL)/(1000*1000/256))
+
+bmk_time_t
+bmk_platform_cpu_clock_monotonic(void)
+{
+
+	return ~inl(TMR1_VALUE) * NSEC_PER_TICK;
+}
+
+bmk_time_t
+bmk_platform_cpu_clock_epochoffset(void)
+{
+
+	return 0;
+}
+
+void
+bmk_platform_cpu_block(bmk_time_t until)
+{
+
+	outl(TMR2_CTRL, TMR_CTRL_EN | TMR_CTRL_IE);
+	outl(TMR2_CLRINT, 0);
+
+	outl(INTR_ENABLE, 0x80);
+	spl0();
+	asm volatile(
+	    "mov r0, #0x0\n"
+	    "mcr p15, 0, r0, c7, c0, 4\n" ::: "r0");
+	splhigh();
+	outl(INTR_CLEAR, 0x80);
+}
+
+int
+cpu_intr_init(int intr)
+{
+
+	intmask |= 1<<intr;
+	outl(INTR_ENABLE, intmask);
+	return 0;
+}
+
+void
+cpu_intr_ack(unsigned mask)
+{
+
+	outl(INTR_ENABLE, mask);
+}

--- a/platform/hw/arch/aarch64/integrator/serialcons.c
+++ b/platform/hw/arch/aarch64/integrator/serialcons.c
@@ -1,0 +1,60 @@
+/*-
+ * Copyright (c) 2015 Antti Kantee.  All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <hw/types.h>
+#include <hw/kernel.h>
+
+#include <integrator/boardreg.h>
+
+/*
+ * Since this is serial, unlike in a framebuffer console,
+ * we can just write a character and that's it.  NetBSD seems to use
+ * a scheme where it waits for the FIFO to be empty before writing to
+ * it, and also after writing to it.  Not sure why you need to wait
+ * after writing.  Therefore, we just wait before writing.
+ */
+void
+cons_putc(int c)
+{
+	volatile uint8_t *const uartdr = (uint8_t *)(UART0 + UARTDR);
+	volatile uint16_t *const uartfr = (uint16_t *)(UART0 + UARTFR);
+	int timo;
+	unsigned char cw = c;
+
+	timo = 150000; /* magic value from NetBSD */
+	while (!(*uartfr & UARTFR_TXFE) && --timo)
+		continue;
+
+	*uartdr = cw;
+}
+
+void
+cons_puts(const char *s)
+{
+	int c;
+
+	while ((c = *s++) != 0)
+		cons_putc(c);
+}

--- a/platform/hw/include/arch/aarch64/inline.h
+++ b/platform/hw/include/arch/aarch64/inline.h
@@ -1,0 +1,27 @@
+static inline uint8_t
+inb(unsigned long address)
+{
+
+	return *(volatile uint8_t *)address;
+}
+
+static inline uint32_t
+inl(unsigned long address)
+{
+
+	return *(volatile uint32_t *)address;
+}
+
+static inline void
+outb(unsigned long address, uint8_t value)
+{
+
+	*(volatile uint8_t *)address = value;
+}
+
+static inline void
+outl(unsigned long address, uint32_t value)
+{
+
+	*(volatile uint32_t *)address = value;
+}

--- a/platform/hw/include/arch/aarch64/md.h
+++ b/platform/hw/include/arch/aarch64/md.h
@@ -1,0 +1,30 @@
+#ifndef _BMK_ARCH_ARM_MD_H_
+#define _BMK_ARCH_ARM_MD_H_
+
+#include <hw/kernel.h>
+
+#define ENTRY(x)        .text; .globl x; .type x,%function; x:
+#define END(x)          .size x, . - x
+
+#define BMK_THREAD_STACK_PAGE_ORDER 1
+#define BMK_THREAD_STACKSIZE ((1<<BMK_THREAD_STACK_PAGE_ORDER) * PAGE_SIZE)
+
+#ifndef _LOCORE
+#include <hw/machine/inline.h>
+
+void splhigh(void);
+void spl0(void);
+
+static inline void
+hlt(void)
+{
+
+	/* dumdidumdum */
+}
+
+void	arm_boot(void);
+void	arm_interrupt(unsigned long *);
+void	arm_undefined(unsigned long *);
+#endif
+
+#endif /* _BMK..._H_ */

--- a/platform/hw/include/arch/aarch64/pcpu.h
+++ b/platform/hw/include/arch/aarch64/pcpu.h
@@ -1,0 +1,7 @@
+#ifndef _BMK_PCPU_PCPU_H_
+#define _BMK_PCPU_PCPU_H_
+
+#define BMK_PCPU_PAGE_SHIFT 12UL
+#define BMK_PCPU_PAGE_SIZE (1<<BMK_PCPU_PAGE_SHIFT)
+
+#endif /* _BMK_PCPU_PCPU_H_ */

--- a/platform/sel4/Makefile
+++ b/platform/sel4/Makefile
@@ -27,6 +27,10 @@ ifeq (${MACHINE},evbarm)
 ARCHDIR=arm
 supported:= true
 endif
+ifeq (${MACHINE},evbarm64-el)
+ARCHDIR=aarch64
+supported:= true
+endif
 ifneq (${supported},true)
 $(error only supported target is x86, you have ${MACHINE})
 endif

--- a/platform/sel4/arch/aarch64/Makefile.inc
+++ b/platform/sel4/arch/aarch64/Makefile.inc
@@ -1,0 +1,17 @@
+#
+# Copyright 2018, Data61
+# Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+# ABN 41 687 119 230.
+#
+# This software may be distributed and modified according to the terms of
+# the BSD 2-Clause license. Note that NO WARRANTY is provided.
+# See "LICENSE_BSD2.txt" for details.
+#
+# @TAG(DATA61_BSD)
+#
+
+SRCS+=	arch/aarch64/clock.c arch/aarch64/arch.c
+
+${RROBJ}/platform/archdirs.stamp:
+	$(Q)mkdir -p ${RROBJ}/platform/arch/aarch64
+	$(Q)touch $@

--- a/platform/sel4/arch/aarch64/arch.c
+++ b/platform/sel4/arch/aarch64/arch.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+
+#include <rumprun/init_data.h>
+#include <sel4/helpers.h>
+#include <bmk-core/sched.h>
+
+void
+arch_init_simple(simple_t *simple)
+{
+    simple->arch_simple.data = (void *) simple->data;
+}

--- a/platform/sel4/arch/aarch64/clock.c
+++ b/platform/sel4/arch/aarch64/clock.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+
+#include <sel4/kernel.h>
+
+#include <utils/util.h>
+#include <platsupport/timer.h>
+#include <bmk-core/core.h>
+#include <bmk-core/platform.h>
+#include <bmk-core/printf.h>
+#include <sel4/helpers.h>
+#include <stdio.h>
+
+/* RTC wall time offset at monotonic time base. */
+static bmk_time_t rtc_epochoffset;
+
+int
+arch_init_clocks(env_t env)
+{
+    /* 
+     * For now, we are using the ltimer implementation in libplatsupport
+     * and don't have a clock like the TSC on AARCH64
+     */
+    return 0;
+}
+
+
+bmk_time_t
+arch_cpu_clock_monotonic(void)
+{
+    bmk_time_t now = 0;
+
+    timer_config_t *simple_timer_config = &env.custom_simple.timer_config;
+    if (simple_timer_config->timer == TIMER_INTERFACE) {
+        now = simple_timer_config->interface.time();
+    } else {
+        UNUSED int err = ltimer_get_time(&simple_timer_config->ltimer.ltimer, (uint64_t *) &now);
+    }
+
+    return now;
+}
+
+bmk_time_t
+arch_cpu_clock_epochoffset(void)
+{
+    return rtc_epochoffset;
+}

--- a/platform/sel4/include/arch/aarch64/md.h
+++ b/platform/sel4/include/arch/aarch64/md.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2018, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+
+#pragma once
+
+#define BMK_THREAD_STACK_PAGE_ORDER 1
+#define BMK_THREAD_STACKSIZE ((1<<BMK_THREAD_STACK_PAGE_ORDER) * BMK_PCPU_PAGE_SIZE)

--- a/platform/sel4/include/arch/aarch64/pcpu.h
+++ b/platform/sel4/include/arch/aarch64/pcpu.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2018, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_BSD)
+ */
+
+#pragma once
+
+#define BMK_PCPU_PAGE_SHIFT 12UL
+#define BMK_PCPU_PAGE_SIZE (1<<BMK_PCPU_PAGE_SHIFT)


### PR DESCRIPTION
Major changes are in lib/libbmk_core/arch/aarch64
Other changes include changes in Makefiles to accomodate aarch64 platform/hw can be ignored for now, those changes are yet to be done as far as sel4 is concerned, we only need to look at platform/sel4